### PR TITLE
Add AWS Marketplace permissions to Bedrock IAM policy

### DIFF
--- a/bedrock-user-permissions.yaml
+++ b/bedrock-user-permissions.yaml
@@ -24,6 +24,13 @@ Resources:
               - "bedrock:InvokeModelWithResponseStream"
             Resource:
               - Ref: AllowedModels
+          - Sid: "AllowMarketplaceSubscriptions"
+            Effect: "Allow"
+            Action:
+              - "aws-marketplace:ViewSubscriptions"
+              - "aws-marketplace:Subscribe"
+              - "aws-marketplace:Unsubscribe"
+            Resource: "*"
 
   IAMUser:
     Type: AWS::IAM::User


### PR DESCRIPTION
## Summary

This PR fixes an issue where IAM users created with the `bedrock-user-permissions.yaml` CloudFormation template cannot invoke Bedrock models for the first time because they lack AWS Marketplace permissions.

## Problem

According to AWS documentation: "For serverless models served from AWS Marketplace, a user with AWS Marketplace permissions must invoke the model once to enable it account-wide."

Previously, users created by this template would encounter permission errors when attempting to invoke Bedrock models from AWS Marketplace for the first time.

## Solution

Added the following AWS Marketplace permissions to the IAM policy:
- `aws-marketplace:ViewSubscriptions`
- `aws-marketplace:Subscribe`
- `aws-marketplace:Unsubscribe`

These permissions allow users to perform the first-time enablement of Bedrock models without requiring separate administrator intervention.

## Changes

- Updated `bedrock-user-permissions.yaml` to include a new policy statement with AWS Marketplace permissions

## Testing

Users created with this updated template will be able to:
1. View available AWS Marketplace subscriptions for Bedrock models
2. Subscribe to/enable Bedrock models from AWS Marketplace
3. Invoke those models without additional permission errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)